### PR TITLE
Use Date format for createdDate

### DIFF
--- a/src/main/java/com/example/entityapi/model/EntityLink.java
+++ b/src/main/java/com/example/entityapi/model/EntityLink.java
@@ -1,5 +1,6 @@
 package com.example.entityapi.model;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.microsoft.spring.data.gremlin.annotation.Edge;
 import com.microsoft.spring.data.gremlin.annotation.EdgeFrom;
 import com.microsoft.spring.data.gremlin.annotation.EdgeTo;
@@ -7,6 +8,7 @@ import lombok.Data;
 import org.springframework.data.annotation.Id;
 
 import javax.validation.constraints.NotNull;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -34,5 +36,9 @@ public class EntityLink
 
     private String createdBy;
 
-    private String createdDate;
+    // Date is used as only that is supported by Gremlin.
+    // JsonFormat is com.fasterxml.jackson (not org.apache.tinkerpop.shaded.jackson)
+    // so this annotation os only used at the user boundary.
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
+    private Date createdDate;
 }

--- a/src/main/java/com/example/entityapi/model/entity/attributes/Comment.java
+++ b/src/main/java/com/example/entityapi/model/entity/attributes/Comment.java
@@ -1,7 +1,7 @@
 package com.example.entityapi.model.entity.attributes;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Data;
+import org.apache.tinkerpop.shaded.jackson.annotation.JsonFormat;
 import org.springframework.data.annotation.Id;
 
 import javax.validation.constraints.NotEmpty;
@@ -21,9 +21,6 @@ public class Comment
 
     private String createdBy;
 
-    // Date is used as only that is supported by Gremlin.
-    // JsonFormat is com.fasterxml.jackson (not org.apache.tinkerpop.shaded.jackson)
-    // so this annotation os only used at the user boundary.
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
     private Date createdDate;
 }

--- a/src/main/java/com/example/entityapi/model/entity/attributes/Comment.java
+++ b/src/main/java/com/example/entityapi/model/entity/attributes/Comment.java
@@ -1,9 +1,11 @@
 package com.example.entityapi.model.entity.attributes;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Data;
 import org.springframework.data.annotation.Id;
 
 import javax.validation.constraints.NotEmpty;
+import java.util.Date;
 
 /**
  * Model for comments.
@@ -19,5 +21,9 @@ public class Comment
 
     private String createdBy;
 
-    private String createdDate;
+    // Date is used as only that is supported by Gremlin.
+    // JsonFormat is com.fasterxml.jackson (not org.apache.tinkerpop.shaded.jackson)
+    // so this annotation os only used at the user boundary.
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
+    private Date createdDate;
 }

--- a/src/main/java/com/example/entityapi/service/EntityLinkService.java
+++ b/src/main/java/com/example/entityapi/service/EntityLinkService.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.Collection;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -21,6 +22,9 @@ public class EntityLinkService implements CrudlRestService<EntityLink>
 {
     @Autowired
     private EntityLinkRepository repository;
+
+    @Autowired
+    private UserService userService;
 
     private Logger logger = LoggerFactory.getLogger(EntityLinkService.class);
 
@@ -56,6 +60,15 @@ public class EntityLinkService implements CrudlRestService<EntityLink>
         if (StringUtils.isBlank(entityLink.getId()))
         {
             entityLink.setId(UUID.randomUUID().toString());
+
+            if (entityLink.getCreatedDate() == null)
+            {
+                entityLink.setCreatedDate(new Date());
+            }
+            if (StringUtils.isBlank(entityLink.getCreatedBy()))
+            {
+                entityLink.setCreatedBy(userService.getUsername());
+            }
         }
 
         logger.debug("Create/update entity link: " + entityLink.getId());

--- a/src/main/java/com/example/entityapi/service/EntityService.java
+++ b/src/main/java/com/example/entityapi/service/EntityService.java
@@ -78,25 +78,6 @@ public class EntityService implements CrudlRestService<Entity>
         }
 
         logger.debug("Create/update entity: " + entity.getId());
-
-        if (entity.getComments() != null)
-        {
-            for (var comment : entity.getComments())
-            {
-                if (StringUtils.isBlank(comment.getId()))
-                {
-                    comment.setId(UUID.randomUUID().toString());
-
-                    if(comment.getCreatedDate() == null){
-                        entity.setCreatedDate(new Date());
-                    }
-                    if(comment.getCreatedBy() == null){
-                        entity.setCreatedBy(userService.getUsername());
-                    }
-                }
-            }
-        }
-
         return repository.save(entity);
     }
 

--- a/src/main/java/com/example/entityapi/service/EntityService.java
+++ b/src/main/java/com/example/entityapi/service/EntityService.java
@@ -65,7 +65,8 @@ public class EntityService implements CrudlRestService<Entity>
             if(entity.getCreatedDate() == null){
                 entity.setCreatedDate(new Date());
             }
-            if(entity.getCreatedBy() == null){
+            if (StringUtils.isBlank(entity.getCreatedBy()))
+            {
                 entity.setCreatedBy(userService.getUsername());
             }
         }
@@ -113,6 +114,15 @@ public class EntityService implements CrudlRestService<Entity>
         if (StringUtils.isBlank(comment.getId()))
         {
             comment.setId(UUID.randomUUID().toString());
+
+            if (comment.getCreatedDate() == null)
+            {
+                comment.setCreatedDate(new Date());
+            }
+            if (StringUtils.isBlank(comment.getCreatedBy()))
+            {
+                comment.setCreatedBy(userService.getUsername());
+            }
         }
 
         var entity = get(id);


### PR DESCRIPTION
# Description

Make all instances of `createdDate` use Date object rather than a string. Additionally this is set along with other meta data fields on create (if they're not provided)

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
